### PR TITLE
Update the status of the export when the batch has been cancelled

### DIFF
--- a/src/Export/Jobs/CollateExportsAndUploadToDisk.php
+++ b/src/Export/Jobs/CollateExportsAndUploadToDisk.php
@@ -15,6 +15,7 @@ use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileIsTooBig;
 use Spatie\SimpleExcel\SimpleExcelReader;
 use Spatie\SimpleExcel\SimpleExcelWriter;
+use Throwable;
 
 class CollateExportsAndUploadToDisk implements ShouldQueue
 {
@@ -116,5 +117,12 @@ class CollateExportsAndUploadToDisk implements ShouldQueue
         });
 
         return $filteredFiles;
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        $this->export->update([
+            'status' => Status::FAILED->value
+        ]);
     }
 }

--- a/src/Export/Jobs/ExportProcessor.php
+++ b/src/Export/Jobs/ExportProcessor.php
@@ -102,6 +102,13 @@ abstract class ExportProcessor implements ShouldQueue
                     "failedJobs" => $batch->failedJobs,
                 ]);
             })
+            ->finally(function (Batch $batch) use ($export) {
+                if ($batch->cancelled()) {
+                    $export->update([
+                        'status' => Status::FAILED->value
+                    ]);
+                }
+            })
             ->allowFailures($this->allowFailures())
             ->name($this->name())
             ->onQueue(self::queueName())

--- a/src/Export/Jobs/ExportToCsv.php
+++ b/src/Export/Jobs/ExportToCsv.php
@@ -33,6 +33,10 @@ class ExportToCsv implements ShouldQueue
      */
     public function handle(): void
     {
+        if ($this->batch()->cancelled()) {
+            return;
+        }
+
         $items = $this->processor->query()
             ->lazy()
             ->forPage($this->page, $this->perPage);


### PR DESCRIPTION
Fixes # .

**What changed?**
- Update the status of `Export` record to "Failed" when:
   - A job from the batch has failed and the batch does not allow failures
   - The job for collating all the export files has failed
- Added condition in `ExportToCsv::class` to check first if the batch has been cancelled before processing

**How can it be tested?**



**What are possible test scenarios?**



**Add notable screenshots here for easier review**


